### PR TITLE
[nix] fix the shell to point to the right libs

### DIFF
--- a/examples/manifests/perfwrap.yaml
+++ b/examples/manifests/perfwrap.yaml
@@ -4,3 +4,4 @@ app:
     perfFreq:
       hertz: 1
     perfLimit: 100000
+    perfEvent: "instructions"

--- a/shell.nix
+++ b/shell.nix
@@ -10,9 +10,11 @@ mkShell {
     hwloc
     linuxPackages.perf
   ];
-  shellHook = ''
-    export NRMSO=${nrm-core}/bin/nrm.so
-    export PYNRMSO=${nrm-core}/bin/pynrm.so
-    export PYTHONPATH=.:$PYTHONPATH
+  shellHook = let pwd = builtins.toPath ./.;
+  in ''
+    export NRMSO=${nrm-core}/lib/ghc-8.6.5/libnrm-core.so
+    export PYNRMSO=${nrm-core}/lib/ghc-8.6.5/libnrm-core-python.so
+    export PYTHONPATH=${pwd}:$PYTHONPATH
+    export PATH=${pwd}/bin:$PATH
   '';
 }


### PR DESCRIPTION
Now that we've changed the names of the nrm-core libraries, we need to update the shell config.