### PR TITLE
Add scopes in downstream API

### DIFF
--- a/nrm/messaging.py
+++ b/nrm/messaging.py
@@ -252,12 +252,35 @@ class UpstreamPubClient(object):
         self.stream.on_recv(self.do_recv_callback)
 
 
-@recv_callback()
 class DownstreamEventServer(RPCServer):
     pass
 
     """Implements the message layer server for the downstream event API."""
 
+    def recv(self):
+        wire = self.socket.recv()
+        _logger.info("received message: %r", wire)
+        return wire
+
+    def do_recv_callback(self, frames):
+        _logger.info("receiving message: %r", frames)
+        assert len(frames) == 2
+        msg = frames[1]
+        try:
+            identity = frames[0].decode()
+        except UnicodeDecodeError:
+            identity = "unassigned"
+        assert self.callback
+        msg = json.loads(msg)
+        if "info" in msg and "threadProgress" in msg["info"]:
+            del msg["info"]["threadProgress"]["scopes"]
+        msg = json.dumps(msg)
+        self.callback(msg, identity)
+
+    def setup_recv_callback(self, callback):
+        self.stream = zmqstream.ZMQStream(self.socket)
+        self.callback = callback
+        self.stream.on_recv(self.do_recv_callback)
 
 def downHeader(*args, **kwargs):
     assert len(kwargs) == 2

--- a/nrm/messaging.py
+++ b/nrm/messaging.py
@@ -253,8 +253,6 @@ class UpstreamPubClient(object):
 
 
 class DownstreamEventServer(RPCServer):
-    pass
-
     """Implements the message layer server for the downstream event API."""
 
     def recv(self):
@@ -281,6 +279,7 @@ class DownstreamEventServer(RPCServer):
         self.stream = zmqstream.ZMQStream(self.socket)
         self.callback = callback
         self.stream.on_recv(self.do_recv_callback)
+
 
 def downHeader(*args, **kwargs):
     assert len(kwargs) == 2

--- a/nrm/progress.py
+++ b/nrm/progress.py
@@ -37,9 +37,6 @@ class Progress(object):
                     "processID": os.getpid(),
                     "rankID": -1,
                     "threadID": 0,
-                    "cpusID" : self.cpus_vec,
-                    "gpusID" : self.gpus_vec,
-                    "nodesID" : self.nodes_vec,
                 }
             },
         )
@@ -60,9 +57,6 @@ class Progress(object):
                         "processID": os.getpid(),
                         "rankID": -1,
                         "threadID": 0,
-                        "cpusID" : self.cpus_vec,
-                        "gpusID" : self.gpus_vec,
-                        "nodesID" : self.nodes_vec,
                     },
                 },
             )

--- a/nrm/progress.py
+++ b/nrm/progress.py
@@ -37,6 +37,9 @@ class Progress(object):
                     "processID": os.getpid(),
                     "rankID": -1,
                     "threadID": 0,
+                    "cpusID" : self.cpus_vec,
+                    "gpusID" : self.gpus_vec,
+                    "nodesID" : self.nodes_vec,
                 }
             },
         )
@@ -57,6 +60,9 @@ class Progress(object):
                         "processID": os.getpid(),
                         "rankID": -1,
                         "threadID": 0,
+                        "cpusID" : self.cpus_vec,
+                        "gpusID" : self.gpus_vec,
+                        "nodesID" : self.nodes_vec,
                     },
                 },
             )

--- a/nrm/schemas/downstreamEvent.json
+++ b/nrm/schemas/downstreamEvent.json
@@ -61,6 +61,7 @@
                         "threadProgress": {
                             "required": [
                                 "downstreamThreadID",
+                                "scopes",
                                 "progress"
                             ],
                             "type": "object",
@@ -104,13 +105,22 @@
                                     "type": "object",
                                     "properties": {
                                         "cpu": {
-                                            "type": "number"
+                                            "type": "array",
+                                            "items": {
+                                                "type": "number"
+                                            }
                                         },
                                         "node": {
-                                            "type": "number"
+                                            "type": "array",
+                                            "items": {
+                                                "type": "number"
+                                            }
                                         },
                                         "gpu": {
-                                            "type": "number"
+                                            "type": "array",
+                                            "items": {
+                                                "type": "number"
+                                            }
                                         }
                                     }
                                 }
@@ -126,7 +136,8 @@
                     "properties": {
                         "threadPause": {
                             "required": [
-                                "downstreamThreadID"
+                                "downstreamThreadID",
+                                "scopes"
                             ],
                             "type": "object",
                             "properties": {
@@ -166,13 +177,22 @@
                                     "type": "object",
                                     "properties": {
                                         "cpu": {
-                                            "type": "number"
+                                            "type": "array",
+                                            "items": {
+                                                "type": "number"
+                                            }
                                         },
                                         "node": {
-                                            "type": "number"
+                                            "type": "array",
+                                            "items": {
+                                                "type": "number"
+                                            }
                                         },
                                         "gpu": {
-                                            "type": "number"
+                                            "type": "array",
+                                            "items": {
+                                                "type": "number"
+                                            }
                                         }
                                     }
                                 }
@@ -189,6 +209,7 @@
                         "threadPhaseContext": {
                             "required": [
                                 "downstreamThreadID",
+                                "scopes",
                                 "phaseContext"
                             ],
                             "type": "object",
@@ -229,13 +250,22 @@
                                     "type": "object",
                                     "properties": {
                                         "cpu": {
-                                            "type": "number"
+                                            "type": "array",
+                                            "items": {
+                                                "type": "number"
+                                            }
                                         },
                                         "node": {
-                                            "type": "number"
+                                            "type": "array",
+                                            "items": {
+                                                "type": "number"
+                                            }
                                         },
                                         "gpu": {
-                                            "type": "number"
+                                            "type": "array",
+                                            "items": {
+                                                "type": "number"
+                                            }
                                         }
                                     }
                                 },
@@ -274,7 +304,8 @@
                     "properties": {
                         "threadPhasePause": {
                             "required": [
-                                "downstreamThreadID"
+                                "downstreamThreadID",
+                                "scopes"
                             ],
                             "type": "object",
                             "properties": {
@@ -314,13 +345,22 @@
                                     "type": "object",
                                     "properties": {
                                         "cpu": {
-                                            "type": "number"
+                                            "type": "array",
+                                            "items": {
+                                                "type": "number"
+                                            }
                                         },
                                         "node": {
-                                            "type": "number"
+                                            "type": "array",
+                                            "items": {
+                                                "type": "number"
+                                            }
                                         },
                                         "gpu": {
-                                            "type": "number"
+                                            "type": "array",
+                                            "items": {
+                                                "type": "number"
+                                            }
                                         }
                                     }
                                 }

--- a/nrm/schemas/downstreamEvent.json
+++ b/nrm/schemas/downstreamEvent.json
@@ -94,6 +94,25 @@
                                             "type": "number"
                                         }
                                     }
+                                },
+                                "scopes": {
+                                    "required": [
+                                        "cpu",
+                                        "node",
+                                        "gpu"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "cpu": {
+                                            "type": "number"
+                                        },
+                                        "node": {
+                                            "type": "number"
+                                        },
+                                        "gpu": {
+                                            "type": "number"
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -134,6 +153,25 @@
                                             "type": "number"
                                         },
                                         "threadID": {
+                                            "type": "number"
+                                        }
+                                    }
+                                },
+                                "scopes": {
+                                    "required": [
+                                        "cpu",
+                                        "node",
+                                        "gpu"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "cpu": {
+                                            "type": "number"
+                                        },
+                                        "node": {
+                                            "type": "number"
+                                        },
+                                        "gpu": {
                                             "type": "number"
                                         }
                                     }
@@ -178,6 +216,25 @@
                                             "type": "number"
                                         },
                                         "threadID": {
+                                            "type": "number"
+                                        }
+                                    }
+                                },
+                                "scopes": {
+                                    "required": [
+                                        "cpu",
+                                        "node",
+                                        "gpu"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "cpu": {
+                                            "type": "number"
+                                        },
+                                        "node": {
+                                            "type": "number"
+                                        },
+                                        "gpu": {
                                             "type": "number"
                                         }
                                     }
@@ -244,6 +301,25 @@
                                             "type": "number"
                                         },
                                         "threadID": {
+                                            "type": "number"
+                                        }
+                                    }
+                                },
+                                "scopes": {
+                                    "required": [
+                                        "cpu",
+                                        "node",
+                                        "gpu"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "cpu": {
+                                            "type": "number"
+                                        },
+                                        "node": {
+                                            "type": "number"
+                                        },
+                                        "gpu": {
                                             "type": "number"
                                         }
                                     }

--- a/nrm/schemas/downstreamEvent.json
+++ b/nrm/schemas/downstreamEvent.json
@@ -136,8 +136,7 @@
                     "properties": {
                         "threadPause": {
                             "required": [
-                                "downstreamThreadID",
-                                "scopes"
+                                "downstreamThreadID"
                             ],
                             "type": "object",
                             "properties": {
@@ -165,34 +164,6 @@
                                         },
                                         "threadID": {
                                             "type": "number"
-                                        }
-                                    }
-                                },
-                                "scopes": {
-                                    "required": [
-                                        "cpu",
-                                        "node",
-                                        "gpu"
-                                    ],
-                                    "type": "object",
-                                    "properties": {
-                                        "cpu": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "number"
-                                            }
-                                        },
-                                        "node": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "number"
-                                            }
-                                        },
-                                        "gpu": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "number"
-                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
Change downstream message format, but remove the field from the message before giving it to nrm-core, as we don't use it in there yet.